### PR TITLE
Expand integration tests; small API cleanups

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -131,7 +131,7 @@ impl<'a> Block<'a> {
     pub fn from_previous(&self, prev: &BlockState) -> Result<BlockState, BlockError> {
         let state = self.open()?;
         if self.compute_pubkey_hash() != prev.next_pubkey_hash {
-            Err(BlockError::PublicKeyHash)
+            Err(BlockError::PubKeyHash)
         } else if state.index != prev.index + 1 {
             Err(BlockError::Index)
         } else if state.previous_hash != prev.block_hash {
@@ -465,7 +465,7 @@ mod tests {
             );
             assert_eq!(
                 Block::new(&buf).from_previous(&bad_prev),
-                Err(BlockError::PublicKeyHash)
+                Err(BlockError::PubKeyHash)
             );
         }
         for bad_block_hash in HashBitFlipper::new(&prev.block_hash) {

--- a/src/block.rs
+++ b/src/block.rs
@@ -131,7 +131,7 @@ impl<'a> Block<'a> {
     pub fn from_previous(&self, prev: &BlockState) -> Result<BlockState, BlockError> {
         let state = self.open()?;
         if self.compute_pubkey_hash() != prev.next_pubkey_hash {
-            Err(BlockError::PubKeyHash)
+            Err(BlockError::PublicKeyHash)
         } else if state.index != prev.index + 1 {
             Err(BlockError::Index)
         } else if state.previous_hash != prev.block_hash {
@@ -465,7 +465,7 @@ mod tests {
             );
             assert_eq!(
                 Block::new(&buf).from_previous(&bad_prev),
-                Err(BlockError::PubKeyHash)
+                Err(BlockError::PublicKeyHash)
             );
         }
         for bad_block_hash in HashBitFlipper::new(&prev.block_hash) {

--- a/src/block.rs
+++ b/src/block.rs
@@ -209,7 +209,8 @@ impl<'a> MutBlock<'a> {
 
     /// Sign block using seed.
     ///
-    /// This sets the pubkey and next_pubkey fields
+    /// This sets the `pubkey` and `next_pubkey_hash` fields, computes the signature, and then
+    /// sets the `signature` field.
     pub fn sign(&mut self, seed: &Seed) {
         let signer = SecretSigner::new(seed);
         signer.sign(self);

--- a/src/block.rs
+++ b/src/block.rs
@@ -258,18 +258,6 @@ mod tests {
     const HEX1: &str = "73f229cc4e11354b11cb17bb718fe9cc9c07192fa05bf09adcc05270a5843d7b";
 
     #[test]
-    fn test_blockerror_to_io_error() {
-        assert_eq!(
-            format!("{:?}", BlockError::Content.to_io_error()),
-            "Custom { kind: Other, error: \"BlockError::Content\" }"
-        );
-        assert_eq!(
-            format!("{:?}", BlockError::Signature.to_io_error()),
-            "Custom { kind: Other, error: \"BlockError::Signature\" }"
-        );
-    }
-
-    #[test]
     fn test_blockstate_effective_chain_hash() {
         let h1 = random_hash();
         let h2 = random_hash();

--- a/src/block.rs
+++ b/src/block.rs
@@ -3,7 +3,8 @@
 use crate::always::*;
 use crate::errors::BlockError;
 use crate::payload::Payload;
-use crate::pksign::verify_block_signature;
+use crate::pksign::{SecretSigner, verify_block_signature};
+use crate::secretseed::Seed;
 use blake3::{Hash, hash};
 
 fn check_block_buf(buf: &[u8]) {
@@ -204,6 +205,12 @@ impl<'a> MutBlock<'a> {
     /// Set hash of the public key that will be used for siging the next block.
     pub fn set_next_pubkey_hash(&mut self, next_pubkey_hash: &Hash) {
         set_hash(self.buf, NEXT_PUBKEY_HASH_RANGE, next_pubkey_hash);
+    }
+
+    /// Sign block using seed.
+    pub fn sign(&mut self, seed: &Seed) {
+        let signer = SecretSigner::new(seed);
+        signer.sign(self);
     }
 
     /// Finalize the block (sets and returns block hash).

--- a/src/block.rs
+++ b/src/block.rs
@@ -202,12 +202,14 @@ impl<'a> MutBlock<'a> {
         set_hash(self.buf, CHAIN_HASH_RANGE, &chain_hash);
     }
 
-    /// Set hash of the public key that will be used for siging the next block.
-    pub fn set_next_pubkey_hash(&mut self, next_pubkey_hash: &Hash) {
+    // Set hash of the public key that will be used for siging the next block.
+    pub(crate) fn set_next_pubkey_hash(&mut self, next_pubkey_hash: &Hash) {
         set_hash(self.buf, NEXT_PUBKEY_HASH_RANGE, next_pubkey_hash);
     }
 
     /// Sign block using seed.
+    ///
+    /// This sets the pubkey and next_pubkey fields
     pub fn sign(&mut self, seed: &Seed) {
         let signer = SecretSigner::new(seed);
         signer.sign(self);

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -331,7 +331,7 @@ mod tests {
         let mut file = tempfile::tempfile().unwrap();
 
         // Generate 1st block
-        let mut seed = Seed::auto_create().unwrap();
+        let seed = Seed::auto_create().unwrap();
         let mut buf1 = [0; BLOCK];
         let payload1 = random_payload();
         let chain_hash = sign_block(&mut buf1, &seed, &payload1, None);
@@ -360,7 +360,6 @@ mod tests {
         let mut buf2 = [0; BLOCK];
         let payload2 = random_payload();
         let _block_hash = sign_block(&mut buf2, &next, &payload2, Some(&tail));
-        seed.commit(next);
         let buf2 = buf2; // Doesn't need to be mutable anymore
         let state2 = Block::new(&buf2).from_previous(&tail).unwrap();
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -40,6 +40,9 @@ impl BlockError {
 /// Error conditions hit when validating a [SecretBlock][crate::secretblock::SecretBlock].
 #[derive(Debug, PartialEq)]
 pub enum SecretBlockError {
+    /// Authenticated decryption of the secret block failed.
+    Decryption,
+
     /// Hash of block content does not match hash in block.
     Content,
 
@@ -57,9 +60,6 @@ pub enum SecretBlockError {
 
     /// Previous hash in block does not match expected external value.
     PreviousHash,
-
-    /// Authenticated decryption of the secret block failed.
-    Decryption,
 }
 
 impl SecretBlockError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,7 +15,7 @@ pub enum BlockError {
     Hash,
 
     /// Hash of public key bytes does not match expected external value.
-    PublicKeyHash,
+    PubKeyHash,
 
     /// Previous hash does not match expected external value.
     PreviousHash,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,7 +15,7 @@ pub enum BlockError {
     Hash,
 
     /// Hash of public key bytes does not match expected external value.
-    PubKeyHash,
+    PublicKeyHash,
 
     /// Previous hash does not match expected external value.
     PreviousHash,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -68,3 +68,32 @@ impl SecretBlockError {
         io::Error::other(format!("SecretBlockError::{self:?}"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_blockerror_to_io_error() {
+        assert_eq!(
+            format!("{:?}", BlockError::Content.to_io_error()),
+            "Custom { kind: Other, error: \"BlockError::Content\" }"
+        );
+        assert_eq!(
+            format!("{:?}", BlockError::Signature.to_io_error()),
+            "Custom { kind: Other, error: \"BlockError::Signature\" }"
+        );
+    }
+
+    #[test]
+    fn test_secretblockerror_to_io_error() {
+        assert_eq!(
+            format!("{:?}", SecretBlockError::Decryption.to_io_error()),
+            "Custom { kind: Other, error: \"SecretBlockError::Decryption\" }"
+        );
+        assert_eq!(
+            format!("{:?}", SecretBlockError::SeedSequence.to_io_error()),
+            "Custom { kind: Other, error: \"SecretBlockError::SeedSequence\" }"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(missing_docs)]
 
-//! 🦓 🔗 ZebraChain: A futuristic cryptographic identity system.
+//! # 🦓 🔗 ZebraChain: A futuristic cryptographic identity system.
 //!
 //! ZebraChain is a logged, quantum safe signing protocol designed to replace the long lived
 //! asymmetric key pairs used to sign software releases (and to sign other super important stuff).
@@ -8,14 +8,14 @@
 //! This is a pre-release crate. The API is still being finalized. The 0.0.x releases make no
 //! API commitments.
 //!
-//! # ⚠️ Security Warning
+//! ## ⚠️ Security Warning
 //!
 //! ZebraChain is not yet suitable for production use.
 //!
 //! This is a nascent implementation of a yet to be finalized protocol. It's also built an quite
 //! new Rust implementations of [ML-DSA] and [SLH-DSA].
 //!
-//! # Quickstart
+//! ##  🚀 Quickstart
 //!
 //! ```
 //! use tempfile;

--- a/src/ownedblock.rs
+++ b/src/ownedblock.rs
@@ -20,7 +20,6 @@ Because the public block can be recreated from the secret block, this gives us a
 
 use crate::block::{BlockState, MutBlock};
 use crate::payload::Payload;
-use crate::pksign::SecretSigner;
 use crate::secretblock::{MutSecretBlock, SecretBlockState};
 use crate::secretchain::derive_chain_secret;
 use crate::secretseed::{Secret, Seed};
@@ -70,8 +69,7 @@ impl<'a> MutOwnedBlock<'a> {
 
     /// Sign public block using `seed` and then save seed in secret block.
     pub fn sign(&mut self, seed: &Seed) {
-        let signer = SecretSigner::new(seed);
-        signer.sign(&mut self.block);
+        self.block.sign(seed);
         self.secret_block.set_seed(seed);
     }
 

--- a/src/secretseed.rs
+++ b/src/secretseed.rs
@@ -36,7 +36,7 @@ pub fn generate_secret() -> Result<Secret, EntropyError> {
 ///
 /// And even if signing with a single algorithm, we still should use a derived secret instead of the
 /// root secret directly.
-pub fn derive_secret(context: &str, secret: &Secret) -> Secret {
+pub(crate) fn derive_secret(context: &str, secret: &Secret) -> Secret {
     if context.len() != 64 {
         panic!(
             "derive_secret(): context string length must be 64; got {}",
@@ -73,8 +73,7 @@ pub struct Seed {
 }
 
 impl Seed {
-    /// FIXME: Remove from public API.
-    pub fn new(secret: Secret, next_secret: Secret) -> Self {
+    pub(crate) fn new(secret: Secret, next_secret: Secret) -> Self {
         if secret == next_secret {
             panic!("new(): secret and next_secret cannot be equal");
         }

--- a/src/secretseed.rs
+++ b/src/secretseed.rs
@@ -79,28 +79,6 @@ impl Seed {
         }
     }
 
-    /// Load a seed from a buffer.
-    pub fn from_buf(buf: &[u8]) -> Result<Self, SecretBlockError> {
-        assert_eq!(buf.len(), SEED);
-        let secret = get_hash(buf, SECRET_RANGE);
-        let next_secret = get_hash(buf, NEXT_SECRET_RANGE);
-        if secret == ZERO_HASH || next_secret == ZERO_HASH || secret == next_secret {
-            Err(SecretBlockError::Seed)
-        } else {
-            Ok(Self {
-                secret,
-                next_secret,
-            })
-        }
-    }
-
-    /// Write seed to buffer.
-    pub fn write_to_buf(&self, buf: &mut [u8]) {
-        assert_eq!(buf.len(), SEED);
-        set_hash(buf, SECRET_RANGE, &self.secret);
-        set_hash(buf, NEXT_SECRET_RANGE, &self.next_secret);
-    }
-
     /// Create a new seed by deriving [Seed::secret], [Seed::next_secret] from `initial_entropy`.
     pub fn create(initial_entropy: &Secret) -> Self {
         let secret = derive_secret(CONTEXT_SECRET, initial_entropy);
@@ -108,7 +86,7 @@ impl Seed {
         Self::new(secret, next_secret)
     }
 
-    /// Creates a new seed using entropy from [generate_secret()].
+    /// Creates a new seed using the initial entropy from [generate_secret()].
     pub fn auto_create() -> Result<Self, EntropyError> {
         let initial_entropy = generate_secret()?; // Only this part can fail
         Ok(Self::create(&initial_entropy))
@@ -134,6 +112,28 @@ impl Seed {
     pub fn auto_advance(&self) -> Result<Self, EntropyError> {
         let new_entropy = generate_secret()?; // Only this part can fail
         Ok(self.advance(&new_entropy))
+    }
+
+    /// Load a seed from a buffer.
+    pub fn from_buf(buf: &[u8]) -> Result<Self, SecretBlockError> {
+        assert_eq!(buf.len(), SEED);
+        let secret = get_hash(buf, SECRET_RANGE);
+        let next_secret = get_hash(buf, NEXT_SECRET_RANGE);
+        if secret == ZERO_HASH || next_secret == ZERO_HASH || secret == next_secret {
+            Err(SecretBlockError::Seed)
+        } else {
+            Ok(Self {
+                secret,
+                next_secret,
+            })
+        }
+    }
+
+    /// Write seed to buffer.
+    pub fn write_to_buf(&self, buf: &mut [u8]) {
+        assert_eq!(buf.len(), SEED);
+        set_hash(buf, SECRET_RANGE, &self.secret);
+        set_hash(buf, NEXT_SECRET_RANGE, &self.next_secret);
     }
 }
 

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use tempfile;
 use zf_zebrachain::{
     ChainStore, DIGEST, MutSecretBlock, OwnedChainStore, PAYLOAD, Payload, SecretChainStore, Seed,
-    generate_secret,
+    generate_secret, sign,
 };
 
 const SAMPLE_ENTROPY_0: &str = "96b3a086291fbcdef17e52e60731e96d8d36ae0944f2aad0c0c12a0c14e161ca";
@@ -85,6 +85,7 @@ fn test_chain_store() {
     let store = ChainStore::new(tmpdir.path());
     let chain_hash = Hash::from_bytes([42; DIGEST]);
     assert!(store.open_chain(&chain_hash).is_err());
+    assert!(store.remove_chain_file(&chain_hash).is_err());
 }
 
 #[test]
@@ -112,6 +113,7 @@ fn test_secret_chain_store() {
     assert_eq!(chain.tail(), &tail);
     store.remove_chain_file(&chain_hash).unwrap();
     assert!(store.open_chain(&chain_hash).is_err());
+    assert!(store.remove_chain_file(&chain_hash).is_err());
 }
 
 #[test]
@@ -165,4 +167,56 @@ fn test_owned_chain_store() {
         Hash::from_hex(BLOCK_HASH_419).unwrap()
     );
     assert_ne!(chain.head(), chain.tail());
+}
+
+#[test]
+fn test_seed_create() {
+    let mut hset = HashSet::new();
+    for i in 0..420 {
+        let initial_entropy = sample_entropy(i);
+        let seed = Seed::create(&initial_entropy);
+        assert!(hset.insert(seed.secret));
+        assert!(hset.insert(seed.next_secret));
+    }
+    assert_eq!(hset.len(), 840);
+}
+
+#[test]
+fn test_seed_auto_create() {
+    let mut hset = HashSet::new();
+    for _ in 0..420 {
+        let seed = Seed::auto_create().unwrap();
+        assert!(hset.insert(seed.secret));
+        assert!(hset.insert(seed.next_secret));
+    }
+    assert_eq!(hset.len(), 840);
+}
+
+#[test]
+fn test_seed_advance() {
+    let mut hset = HashSet::new();
+    let seed = Seed::auto_create().unwrap();
+    assert!(hset.insert(seed.secret));
+    assert!(hset.insert(seed.next_secret));
+    for i in 0..420 {
+        let new_entropy = sample_entropy(i);
+        let seed2 = seed.advance(&new_entropy);
+        assert!(!hset.insert(seed2.secret));
+        assert!(hset.insert(seed2.next_secret));
+    }
+    assert_eq!(hset.len(), 422);
+}
+
+#[test]
+fn test_seed_auto_advance() {
+    let mut hset = HashSet::new();
+    let seed = Seed::auto_create().unwrap();
+    assert!(hset.insert(seed.secret));
+    assert!(hset.insert(seed.next_secret));
+    for _ in 0..420 {
+        let seed2 = seed.auto_advance().unwrap();
+        assert!(!hset.insert(seed2.secret));
+        assert!(hset.insert(seed2.next_secret));
+    }
+    assert_eq!(hset.len(), 422);
 }

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use tempfile;
 use zf_zebrachain::{
     ChainStore, DIGEST, MutSecretBlock, OwnedChainStore, PAYLOAD, Payload, SecretChainStore, Seed,
-    generate_secret, sign,
+    generate_secret,
 };
 
 const SAMPLE_ENTROPY_0: &str = "96b3a086291fbcdef17e52e60731e96d8d36ae0944f2aad0c0c12a0c14e161ca";
@@ -167,56 +167,4 @@ fn test_owned_chain_store() {
         Hash::from_hex(BLOCK_HASH_419).unwrap()
     );
     assert_ne!(chain.head(), chain.tail());
-}
-
-#[test]
-fn test_seed_create() {
-    let mut hset = HashSet::new();
-    for i in 0..420 {
-        let initial_entropy = sample_entropy(i);
-        let seed = Seed::create(&initial_entropy);
-        assert!(hset.insert(seed.secret));
-        assert!(hset.insert(seed.next_secret));
-    }
-    assert_eq!(hset.len(), 840);
-}
-
-#[test]
-fn test_seed_auto_create() {
-    let mut hset = HashSet::new();
-    for _ in 0..420 {
-        let seed = Seed::auto_create().unwrap();
-        assert!(hset.insert(seed.secret));
-        assert!(hset.insert(seed.next_secret));
-    }
-    assert_eq!(hset.len(), 840);
-}
-
-#[test]
-fn test_seed_advance() {
-    let mut hset = HashSet::new();
-    let seed = Seed::auto_create().unwrap();
-    assert!(hset.insert(seed.secret));
-    assert!(hset.insert(seed.next_secret));
-    for i in 0..420 {
-        let new_entropy = sample_entropy(i);
-        let seed2 = seed.advance(&new_entropy);
-        assert!(!hset.insert(seed2.secret));
-        assert!(hset.insert(seed2.next_secret));
-    }
-    assert_eq!(hset.len(), 422);
-}
-
-#[test]
-fn test_seed_auto_advance() {
-    let mut hset = HashSet::new();
-    let seed = Seed::auto_create().unwrap();
-    assert!(hset.insert(seed.secret));
-    assert!(hset.insert(seed.next_secret));
-    for _ in 0..420 {
-        let seed2 = seed.auto_advance().unwrap();
-        assert!(!hset.insert(seed2.secret));
-        assert!(hset.insert(seed2.next_secret));
-    }
-    assert_eq!(hset.len(), 422);
 }

--- a/tests/block_test.rs
+++ b/tests/block_test.rs
@@ -43,7 +43,7 @@ fn test_block() {
     let block = Block::new(&buf);
     assert_eq!(
         block.from_previous(&block_state_1),
-        Err(BlockError::PubKeyHash)
+        Err(BlockError::PublicKeyHash)
     );
 }
 

--- a/tests/block_test.rs
+++ b/tests/block_test.rs
@@ -1,4 +1,4 @@
-use zf_zebrachain::{BLOCK, MutBlock, PAYLOAD, Payload, Seed};
+use zf_zebrachain::{BLOCK, Block, BlockError, DIGEST, Hash, MutBlock, PAYLOAD, Payload, Seed};
 
 fn random_payload_buf() -> [u8; PAYLOAD] {
     let mut buf = [0; PAYLOAD];
@@ -8,6 +8,43 @@ fn random_payload_buf() -> [u8; PAYLOAD] {
 
 fn random_payload() -> Payload {
     Payload::from_buf(&random_payload_buf())
+}
+
+#[test]
+fn test_block() {
+    let buf = [0; BLOCK];
+    let block = Block::new(&buf);
+    let block_hash = Hash::from_bytes([69; DIGEST]);
+    assert_eq!(
+        block.from_hash_at_index(&block_hash, 0),
+        Err(BlockError::Content)
+    );
+
+    let mut buf = [0; BLOCK];
+
+    let payload_0 = random_payload();
+    let seed = Seed::auto_create().unwrap();
+    let mut mblock = MutBlock::new(&mut buf, &payload_0);
+    mblock.sign(&seed);
+    let block_hash_0 = mblock.finalize();
+    let block = Block::new(&buf);
+    let block_state_0 = block.from_hash_at_index(&block_hash_0, 0).unwrap();
+
+    let payload_1 = random_payload();
+    let seed = seed.auto_advance().unwrap();
+    let mut mblock = MutBlock::new(&mut buf, &payload_1);
+    mblock.set_previous(&block_state_0);
+    mblock.sign(&seed);
+    let block_hash_1 = mblock.finalize();
+    let block = Block::new(&buf);
+    let block_state_1 = block.from_hash_at_index(&block_hash_1, 1).unwrap();
+    let block = Block::new(&buf);
+    assert_eq!(block.from_previous(&block_state_0).unwrap(), block_state_1);
+    let block = Block::new(&buf);
+    assert_eq!(
+        block.from_previous(&block_state_1),
+        Err(BlockError::PubKeyHash)
+    );
 }
 
 #[test]

--- a/tests/block_test.rs
+++ b/tests/block_test.rs
@@ -1,0 +1,23 @@
+use zf_zebrachain::{BLOCK, MutBlock, PAYLOAD, Payload, Seed};
+
+fn random_payload_buf() -> [u8; PAYLOAD] {
+    let mut buf = [0; PAYLOAD];
+    getrandom::fill(&mut buf).unwrap();
+    buf
+}
+
+fn random_payload() -> Payload {
+    Payload::from_buf(&random_payload_buf())
+}
+
+#[test]
+fn test_mutblock() {
+    let payload = random_payload();
+    let seed = Seed::auto_create().unwrap();
+    let mut buf = [0; BLOCK];
+    let mut block = MutBlock::new(&mut buf, &payload);
+    block.sign(&seed);
+    let block_hash = block.finalize();
+    assert_ne!(buf, [0; BLOCK]);
+    assert!(buf.starts_with(block_hash.as_bytes()));
+}

--- a/tests/block_test.rs
+++ b/tests/block_test.rs
@@ -43,7 +43,7 @@ fn test_block() {
     let block = Block::new(&buf);
     assert_eq!(
         block.from_previous(&block_state_1),
-        Err(BlockError::PublicKeyHash)
+        Err(BlockError::PubKeyHash)
     );
 }
 

--- a/tests/secretseed_test.rs
+++ b/tests/secretseed_test.rs
@@ -13,24 +13,6 @@ fn test_generate_secret() {
 }
 
 #[test]
-fn test_seed_from_buf() {
-    let mut buf = [0; DIGEST * 2];
-    getrandom::fill(&mut buf).unwrap();
-    let seed = Seed::from_buf(&buf).unwrap();
-    assert_eq!(&buf[..DIGEST], seed.secret.as_bytes());
-    assert_eq!(&buf[DIGEST..], seed.next_secret.as_bytes());
-}
-
-#[test]
-fn test_seed_write_to_buf() {
-    let seed = Seed::auto_create().unwrap();
-    let mut buf = [0; DIGEST * 2];
-    seed.write_to_buf(&mut buf);
-    assert_eq!(&buf[..DIGEST], seed.secret.as_bytes());
-    assert_eq!(&buf[DIGEST..], seed.next_secret.as_bytes());
-}
-
-#[test]
 fn test_seed_create() {
     let mut hset = HashSet::new();
     for _ in 0..420 {
@@ -82,4 +64,22 @@ fn test_seed_auto_advance() {
         assert!(hset.insert(seed2.next_secret));
     }
     assert_eq!(hset.len(), 422);
+}
+
+#[test]
+fn test_seed_from_buf() {
+    let mut buf = [0; DIGEST * 2];
+    getrandom::fill(&mut buf).unwrap();
+    let seed = Seed::from_buf(&buf).unwrap();
+    assert_eq!(&buf[..DIGEST], seed.secret.as_bytes());
+    assert_eq!(&buf[DIGEST..], seed.next_secret.as_bytes());
+}
+
+#[test]
+fn test_seed_write_to_buf() {
+    let seed = Seed::auto_create().unwrap();
+    let mut buf = [0; DIGEST * 2];
+    seed.write_to_buf(&mut buf);
+    assert_eq!(&buf[..DIGEST], seed.secret.as_bytes());
+    assert_eq!(&buf[DIGEST..], seed.next_secret.as_bytes());
 }

--- a/tests/secretseed_test.rs
+++ b/tests/secretseed_test.rs
@@ -1,5 +1,6 @@
+use getrandom;
 use std::collections::HashSet;
-use zf_zebrachain::{Seed, generate_secret};
+use zf_zebrachain::{DIGEST, Seed, generate_secret};
 
 #[test]
 fn test_generate_secret() {
@@ -9,6 +10,24 @@ fn test_generate_secret() {
         assert!(hset.insert(secret));
     }
     assert_eq!(hset.len(), 420);
+}
+
+#[test]
+fn test_seed_from_buf() {
+    let mut buf = [0; DIGEST * 2];
+    getrandom::fill(&mut buf).unwrap();
+    let seed = Seed::from_buf(&buf).unwrap();
+    assert_eq!(&buf[..DIGEST], seed.secret.as_bytes());
+    assert_eq!(&buf[DIGEST..], seed.next_secret.as_bytes());
+}
+
+#[test]
+fn test_seed_write_to_buf() {
+    let seed = Seed::auto_create().unwrap();
+    let mut buf = [0; DIGEST * 2];
+    seed.write_to_buf(&mut buf);
+    assert_eq!(&buf[..DIGEST], seed.secret.as_bytes());
+    assert_eq!(&buf[DIGEST..], seed.next_secret.as_bytes());
 }
 
 #[test]

--- a/tests/secretseed_test.rs
+++ b/tests/secretseed_test.rs
@@ -1,0 +1,66 @@
+use std::collections::HashSet;
+use zf_zebrachain::{Seed, generate_secret};
+
+#[test]
+fn test_generate_secret() {
+    let mut hset = HashSet::new();
+    for _ in 0..420 {
+        let secret = generate_secret().unwrap();
+        assert!(hset.insert(secret));
+    }
+    assert_eq!(hset.len(), 420);
+}
+
+#[test]
+fn test_seed_create() {
+    let mut hset = HashSet::new();
+    for _ in 0..420 {
+        let initial_entropy = generate_secret().unwrap();
+        assert!(hset.insert(initial_entropy));
+        let seed = Seed::create(&initial_entropy);
+        assert!(hset.insert(seed.secret));
+        assert!(hset.insert(seed.next_secret));
+    }
+    assert_eq!(hset.len(), 1260);
+}
+
+#[test]
+fn test_seed_auto_create() {
+    let mut hset = HashSet::new();
+    for _ in 0..420 {
+        let seed = Seed::auto_create().unwrap();
+        assert!(hset.insert(seed.secret));
+        assert!(hset.insert(seed.next_secret));
+    }
+    assert_eq!(hset.len(), 840);
+}
+
+#[test]
+fn test_seed_advance() {
+    let mut hset = HashSet::new();
+    let seed = Seed::auto_create().unwrap();
+    assert!(hset.insert(seed.secret));
+    assert!(hset.insert(seed.next_secret));
+    for _ in 0..420 {
+        let new_entropy = generate_secret().unwrap();
+        assert!(hset.insert(new_entropy));
+        let seed2 = seed.advance(&new_entropy);
+        assert!(!hset.insert(seed2.secret));
+        assert!(hset.insert(seed2.next_secret));
+    }
+    assert_eq!(hset.len(), 842);
+}
+
+#[test]
+fn test_seed_auto_advance() {
+    let mut hset = HashSet::new();
+    let seed = Seed::auto_create().unwrap();
+    assert!(hset.insert(seed.secret));
+    assert!(hset.insert(seed.next_secret));
+    for _ in 0..420 {
+        let seed2 = seed.auto_advance().unwrap();
+        assert!(!hset.insert(seed2.secret));
+        assert!(hset.insert(seed2.next_secret));
+    }
+    assert_eq!(hset.len(), 422);
+}


### PR DESCRIPTION
Starts more serious work nailing down the API via the integration tests, and adds some small API improvements (mostly removes more stuff that shouldn't be pub... or there at all).

Notably, MutBlock.sign() was added to match MutOwnedBlock.sign(), plus it's super handy for writing the integration tests (which means it will also be handy for application level unit test).