### PR TITLE
Use a ML-DSA signing context string

### DIFF
--- a/src/always.rs
+++ b/src/always.rs
@@ -116,20 +116,23 @@ pub(crate) const SEC_PREV_HASH_RANGE: Range<usize> = get_secrange(5);
 pub(crate) const BLOCK_READ_BUF: usize = BLOCK * 64;
 pub(crate) const SECRET_BLOCK_AEAD_READ_BUF: usize = SECRET_BLOCK_AEAD * 64;
 
-pub static CONTEXT_SECRET: &str =
+pub(crate) static CONTEXT_SECRET: &str =
     "ed149ef77826374035fd3a1e2c1bf3b39539333d5a8bc1f7e788736430efc7f2";
-pub static CONTEXT_SECRET_NEXT: &str =
+pub(crate) static CONTEXT_SECRET_NEXT: &str =
     "a0ec84dd51dabc0cfb7f61c936c8577c15982715b77ed5d6582cb01108769831";
-pub static CONTEXT_ED25519: &str =
+pub(crate) static CONTEXT_ED25519: &str =
     "e3481172dcedab349a13152e9d002494f1ae292c868e049d93926c3a58a48408";
-pub static CONTEXT_ML_DSA: &str =
+pub(crate) static CONTEXT_ML_DSA: &str =
     "e665ee96123e46d74e76dc53bdc64df06d72c238d574b7c153305f5e63063350";
-//pub static CONTEXT_SLH_DSA: &str =
+//pub(crate) static CONTEXT_SLH_DSA: &str =
 //    "b5de7bead4cac0fb4fe60cbb2ef31cb2c0590adb10f0764769cd5b0e0d7d11c1";
-pub static CONTEXT_STORE_KEY: &str =
+pub(crate) static CONTEXT_STORE_KEY: &str =
     "0179f9dd9cb5b0af47079d3a102872a32744b7f7aa8a5f22f7c0a16ba8549601";
-pub static CONTEXT_STORE_NONCE: &str =
+pub(crate) static CONTEXT_STORE_NONCE: &str =
     "dc49809016fca0a126c5df6d373e90c48683e664ecba0440ae59523d93e13515";
+
+pub(crate) static SIGNING_CXT_ML_DSA: &str =
+    "270973c068ca5b0188c0e0b89f286d1a8c6a3b3c176aa07b3ae3a519fd65032f";
 
 pub(crate) const ZERO_HASH: Hash = Hash::from_bytes([0; DIGEST]);
 

--- a/src/always.rs
+++ b/src/always.rs
@@ -131,8 +131,8 @@ pub(crate) static CONTEXT_STORE_KEY: &str =
 pub(crate) static CONTEXT_STORE_NONCE: &str =
     "dc49809016fca0a126c5df6d373e90c48683e664ecba0440ae59523d93e13515";
 
-pub(crate) static SIGNING_CXT_ML_DSA: &str =
-    "270973c068ca5b0188c0e0b89f286d1a8c6a3b3c176aa07b3ae3a519fd65032f";
+pub(crate) static SIGNING_CXT_ML_DSA: &[u8] =
+    b"270973c068ca5b0188c0e0b89f286d1a8c6a3b3c176aa07b3ae3a519fd65032f";
 
 pub(crate) const ZERO_HASH: Hash = Hash::from_bytes([0; DIGEST]);
 

--- a/src/always.rs
+++ b/src/always.rs
@@ -133,6 +133,8 @@ pub(crate) static CONTEXT_STORE_NONCE: &str =
 
 pub(crate) static SIGNING_CXT_ML_DSA: &[u8] =
     b"270973c068ca5b0188c0e0b89f286d1a8c6a3b3c176aa07b3ae3a519fd65032f";
+//pub(crate) static SIGNING_CXT_SLH_DSA: &[u8] =
+//    b"b71cd1500453530f76d0a4e47863c69bb4842a42ba088532d58d11c149489853";
 
 pub(crate) const ZERO_HASH: Hash = Hash::from_bytes([0; DIGEST]);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub use always::{BLOCK, DIGEST, PAYLOAD};
 pub use block::{Block, BlockState, MutBlock};
 pub use chain::{Chain, ChainIter, ChainStore, CheckPoint};
 pub use errors::{BlockError, SecretBlockError};
-pub use ownedblock::{MutOwnedBlock, OwnedBlockState, sign};
+pub use ownedblock::{MutOwnedBlock, OwnedBlockState};
 pub use ownedchain::{OwnedChain, OwnedChainStore};
 pub use payload::Payload;
 pub use secretblock::{MutSecretBlock, SecretBlock, SecretBlockState};

--- a/src/pksign.rs
+++ b/src/pksign.rs
@@ -64,7 +64,7 @@ impl KeyPair {
         let sig = self
             .mldsa
             .signing_key()
-            .sign_deterministic(block.as_signable2(), b"")
+            .sign_deterministic(block.as_signable2(), SIGNING_CXT_ML_DSA)
             .unwrap();
         block.as_mut_signature()[SIG_MLDSA_RANGE].copy_from_slice(sig.encode().as_slice());
     }
@@ -145,7 +145,7 @@ impl<'a> Hybrid<'a> {
         let pubkey = ml_dsa::VerifyingKey::<MlDsa65>::decode(&pubenc);
         let sigenc = ml_dsa::EncodedSignature::<MlDsa65>::try_from(self.as_sig_mldsa()).unwrap();
         if let Some(sig) = ml_dsa::Signature::<MlDsa65>::decode(&sigenc) {
-            pubkey.verify_with_context(self.block.as_signable2(), b"", &sig)
+            pubkey.verify_with_context(self.block.as_signable2(), SIGNING_CXT_ML_DSA, &sig)
         } else {
             false
         }

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -17,8 +17,8 @@ const SAMPLE_STORAGE_SECRET_419: &str =
 const SAMPLE_PAYLOAD_0: &str = "c0c76cbfd80b970d138cce4e466327b1f2ba96a7de9ecc2c98b8f4e7e462a8bc";
 const SAMPLE_PAYLOAD_419: &str = "e9961e428776cb08e4c3c7c55d912716a1f9edca74da0adb8a7a7805bb536788";
 
-const BLOCK_HASH_0: &str = "1e3f1868ce7505deb6682d45874e9dfdbf1ad9a7dfc0ad80070f83489d763262";
-const BLOCK_HASH_419: &str = "9d663c74c5417a19b250a6ee69228f0c2e272522ca59a5f066f752a8f20902c9";
+const BLOCK_HASH_0: &str = "21826e128e0d2e790d02471e84f38a8717d3859c09ca32ad300b42686abb14c0";
+const BLOCK_HASH_419: &str = "2c20f1a0e40886eefcb24622d7cd42469b4678487d703b8ed17dd7be54277525";
 
 fn sample_entropy(index: u128) -> Hash {
     let mut h = Hasher::new();


### PR DESCRIPTION
I've been meaning to do this for a bit, but we should use an application specific signing context string for the ML-DSA signing and verification. That's best practice, yo. This is a breaking change in the protocol because it changes the values of the ML-DSA signatures.

I also couldn't resit removing the sign() function from the public API as it was only being used in 1 test and isn't useful anymore.